### PR TITLE
[issue-fix] Replace in-memory storage with Azure Cosmos DB for ticket persistence

### DIFF
--- a/backend/cosmosClient.js
+++ b/backend/cosmosClient.js
@@ -1,0 +1,50 @@
+/**
+ * Azure Cosmos DB client setup for the Support Ticket API.
+ *
+ * Based on Microsoft Learn documentation:
+ *   - Quickstart Node.js: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/quickstart-nodejs
+ *   - Get started (JS):   https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-get-started
+ *
+ * Required environment variables:
+ *   COSMOS_ENDPOINT      — Your Cosmos DB account URI
+ *   COSMOS_KEY           — Your Cosmos DB account primary key
+ *   COSMOS_DATABASE_ID   — (optional) Database name, defaults to "SupportTicketsDB"
+ *   COSMOS_CONTAINER_ID  — (optional) Container name, defaults to "Tickets"
+ */
+
+const { CosmosClient } = require("@azure/cosmos");
+
+const endpoint = process.env.COSMOS_ENDPOINT;
+const key = process.env.COSMOS_KEY;
+const databaseId = process.env.COSMOS_DATABASE_ID || "SupportTicketsDB";
+const containerId = process.env.COSMOS_CONTAINER_ID || "Tickets";
+
+if (!endpoint || !key) {
+  throw new Error(
+    "Missing required environment variables: COSMOS_ENDPOINT and COSMOS_KEY must be set."
+  );
+}
+
+// Create a single CosmosClient instance to reuse across the application.
+// Source: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-get-started
+const client = new CosmosClient({ endpoint, key });
+
+/**
+ * Returns the Cosmos DB container, creating the database and container
+ * if they do not already exist.
+ *
+ * Partition key is set to "/id" so every ticket is its own logical partition,
+ * enabling efficient point reads using (id, id) as the (id, partitionKey) pair.
+ *
+ * Source: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/quickstart-nodejs
+ */
+async function getContainer() {
+  const { database } = await client.databases.createIfNotExists({ id: databaseId });
+  const { container } = await database.containers.createIfNotExists({
+    id: containerId,
+    partitionKey: { paths: ["/id"] },
+  });
+  return container;
+}
+
+module.exports = { getContainer };

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "express": "^4.21.0",
     "cors": "^2.8.5",
-    "helmet": "^8.0.0"
+    "helmet": "^8.0.0",
+    "@azure/cosmos": "^4.0.0"
   }
 }

--- a/backend/routes/tickets.js
+++ b/backend/routes/tickets.js
@@ -1,93 +1,200 @@
+/**
+ * Ticket routes — backed by Azure Cosmos DB for NoSQL.
+ *
+ * All CRUD patterns follow official Microsoft Learn documentation:
+ *   Create item:  https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-create-item
+ *   Read item:    https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-read-item
+ *   Query items:  https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-query-items
+ *   Replace item: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-replace-item
+ *   Quickstart:   https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/quickstart-nodejs
+ */
+
 const express = require("express");
+const { randomUUID } = require("crypto");
 const { validateTicket } = require("../middleware/validation");
 const { teams, routeTicket } = require("../data/teams");
+const { getContainer } = require("../cosmosClient");
 
 const router = express.Router();
 
-// In-memory store (replace with a database in production)
-const tickets = [];
-let nextId = 1;
+// ---------------------------------------------------------------------------
+// GET /api/tickets — list all tickets, with optional filters
+//
+// Uses a parameterized SQL query against Cosmos DB.
+// Source: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-query-items
+// ---------------------------------------------------------------------------
+router.get("/", async (req, res) => {
+  try {
+    const { status, team, priority } = req.query;
 
-// GET /api/tickets — list all tickets
-router.get("/", (req, res) => {
-  const { status, team, priority } = req.query;
+    // Build a dynamic WHERE clause from whichever filters were supplied.
+    const conditions = [];
+    const parameters = [];
 
-  let filtered = [...tickets];
-  if (status) filtered = filtered.filter(t => t.status === status);
-  if (team) filtered = filtered.filter(t => t.assignedTeam.id === team);
-  if (priority) filtered = filtered.filter(t => t.priority === priority);
+    if (status) {
+      conditions.push("c.status = @status");
+      parameters.push({ name: "@status", value: status });
+    }
+    if (team) {
+      conditions.push("c.assignedTeam.id = @team");
+      parameters.push({ name: "@team", value: team });
+    }
+    if (priority) {
+      conditions.push("c.priority = @priority");
+      parameters.push({ name: "@priority", value: priority });
+    }
 
-  res.json({
-    count: filtered.length,
-    tickets: filtered.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
-  });
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const querySpec = {
+      query: `SELECT * FROM c ${whereClause} ORDER BY c.createdAt DESC`,
+      parameters,
+    };
+
+    const container = await getContainer();
+
+    // .fetchAll() returns { resources: [...] }
+    // Source: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-query-items
+    const { resources: tickets } = await container.items.query(querySpec).fetchAll();
+
+    res.json({ count: tickets.length, tickets });
+  } catch (err) {
+    console.error("Error listing tickets:", err.message);
+    res.status(500).json({ error: "Failed to retrieve tickets" });
+  }
 });
 
-// GET /api/tickets/teams — list available teams
+// ---------------------------------------------------------------------------
+// GET /api/tickets/teams — list available teams (static, no DB call needed)
+// ---------------------------------------------------------------------------
 router.get("/teams", (req, res) => {
   res.json(teams.map(t => ({ id: t.id, name: t.name, description: t.description })));
 });
 
-// GET /api/tickets/:id — get a single ticket
-router.get("/:id", (req, res) => {
-  const ticket = tickets.find(t => t.id === parseInt(req.params.id, 10));
-  if (!ticket) {
-    return res.status(404).json({ error: "Ticket not found" });
+// ---------------------------------------------------------------------------
+// GET /api/tickets/:id — get a single ticket by id
+//
+// Uses a point read — the most efficient Cosmos DB operation.
+// container.item(id, partitionKeyValue).read()
+// Source: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-read-item
+// ---------------------------------------------------------------------------
+router.get("/:id", async (req, res) => {
+  try {
+    const { id } = req.params;
+    const container = await getContainer();
+
+    // Second argument is the partition key value.
+    // Because our partition key path is "/id", it equals the document id.
+    const { resource: ticket } = await container.item(id, id).read();
+
+    if (!ticket) {
+      return res.status(404).json({ error: "Ticket not found" });
+    }
+
+    res.json(ticket);
+  } catch (err) {
+    if (err.code === 404) {
+      return res.status(404).json({ error: "Ticket not found" });
+    }
+    console.error("Error reading ticket:", err.message);
+    res.status(500).json({ error: "Failed to retrieve ticket" });
   }
-  res.json(ticket);
 });
 
-// POST /api/tickets — create a new ticket
-router.post("/", validateTicket, (req, res) => {
-  const { title, description, priority, category, contactEmail } = req.body;
+// ---------------------------------------------------------------------------
+// POST /api/tickets — create a new ticket and persist to Cosmos DB
+//
+// Uses container.items.create(item)
+// Source: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-create-item
+//
+// NOTE: Cosmos DB requires "id" to be a string. We use crypto.randomUUID()
+// (built into Node.js 14.17+) to generate a unique string id for each ticket.
+// ---------------------------------------------------------------------------
+router.post("/", validateTicket, async (req, res) => {
+  try {
+    const { title, description, priority, category, contactEmail } = req.body;
+    const routing = routeTicket(title, description, category);
 
-  const routing = routeTicket(title, description, category);
+    const ticket = {
+      id: randomUUID(),           // Cosmos DB "id" must be a string
+      title,
+      description,
+      priority,
+      category: category || null,
+      contactEmail: contactEmail || null,
+      status: "open",
+      assignedTeam: {
+        id: routing.team.id,
+        name: routing.team.name,
+      },
+      routing: {
+        confidence: routing.confidence,
+        method: routing.method,
+        matchedKeywords: routing.matchedKeywords || [],
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
 
-  const ticket = {
-    id: nextId++,
-    title,
-    description,
-    priority,
-    category: category || null,
-    contactEmail: contactEmail || null,
-    status: "open",
-    assignedTeam: {
-      id: routing.team.id,
-      name: routing.team.name
-    },
-    routing: {
-      confidence: routing.confidence,
-      method: routing.method,
-      matchedKeywords: routing.matchedKeywords || []
-    },
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString()
-  };
+    const container = await getContainer();
 
-  tickets.push(ticket);
+    // .create() stores the document and returns the persisted resource.
+    // Source: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-create-item
+    const { resource: created } = await container.items.create(ticket);
 
-  res.status(201).json({
-    message: "Ticket created and routed successfully",
-    ticket
-  });
+    res.status(201).json({
+      message: "Ticket created and routed successfully",
+      ticket: created,
+    });
+  } catch (err) {
+    console.error("Error creating ticket:", err.message);
+    res.status(500).json({ error: "Failed to create ticket" });
+  }
 });
 
+// ---------------------------------------------------------------------------
 // PATCH /api/tickets/:id — update ticket status
-router.patch("/:id", (req, res) => {
-  const ticket = tickets.find(t => t.id === parseInt(req.params.id, 10));
-  if (!ticket) {
-    return res.status(404).json({ error: "Ticket not found" });
+//
+// Uses container.item(id, partitionKeyValue).replace(updatedItem)
+// Source: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-replace-item
+// ---------------------------------------------------------------------------
+router.patch("/:id", async (req, res) => {
+  try {
+    const { id } = req.params;
+    const container = await getContainer();
+
+    // First do a point read to get the current document.
+    // Source: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-read-item
+    const { resource: existing } = await container.item(id, id).read();
+
+    if (!existing) {
+      return res.status(404).json({ error: "Ticket not found" });
+    }
+
+    const validStatuses = ["open", "in-progress", "resolved", "closed"];
+    if (req.body.status && !validStatuses.includes(req.body.status)) {
+      return res.status(400).json({
+        error: `Status must be one of: ${validStatuses.join(", ")}`,
+      });
+    }
+
+    // Merge the changes and replace the document in Cosmos DB.
+    // Source: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-javascript-replace-item
+    const updated = {
+      ...existing,
+      status: req.body.status ?? existing.status,
+      updatedAt: new Date().toISOString(),
+    };
+
+    const { resource: replaced } = await container.item(id, id).replace(updated);
+
+    res.json({ message: "Ticket updated", ticket: replaced });
+  } catch (err) {
+    if (err.code === 404) {
+      return res.status(404).json({ error: "Ticket not found" });
+    }
+    console.error("Error updating ticket:", err.message);
+    res.status(500).json({ error: "Failed to update ticket" });
   }
-
-  const validStatuses = ["open", "in-progress", "resolved", "closed"];
-  if (req.body.status && !validStatuses.includes(req.body.status)) {
-    return res.status(400).json({ error: `Status must be one of: ${validStatuses.join(", ")}` });
-  }
-
-  if (req.body.status) ticket.status = req.body.status;
-  ticket.updatedAt = new Date().toISOString();
-
-  res.json({ message: "Ticket updated", ticket });
 });
 
 module.exports = router;


### PR DESCRIPTION
Closes #6

## What changed

Replaced the volatile in-memory `tickets` array in `backend/routes/tickets.js` with persistent Azure Cosmos DB storage using the official `@azure/cosmos` Node.js SDK.

### Files modified

| File | Change |
|---|---|
| `backend/package.json` | Added `@azure/cosmos ^4.0.0` dependency |
| `backend/cosmosClient.js` | **New** — `CosmosClient` singleton + `getContainer()` factory |
| `backend/routes/tickets.js` | All routes rewritten as `async` using Cosmos DB CRUD |

### Implementation details

**`cosmosClient.js`** — based on [Get started with Azure Cosmos DB for NoSQL and JavaScript]((learn.microsoft.com/redacted)
- Creates a single `CosmosClient` instance (reused across requests)
- `getContainer()` calls `createIfNotExists` for both the database and container on every invocation — idempotent and safe on restart
- Partition key path set to `/id` so each ticket is its own partition, enabling efficient point reads

**`routes/tickets.js`** — CRUD patterns per Microsoft Learn:
- **List** (`GET /`): [Parameterized SQL query]((learn.microsoft.com/redacted) with dynamic `WHERE` clause for optional `status`/`team`/`priority` filters
- **Read** (`GET /:id`): [Point read]((learn.microsoft.com/redacted) via `container.item(id, id).read()` — most efficient Cosmos DB operation
- **Create** (`POST /`): [`container.items.create(ticket)`]((learn.microsoft.com/redacted) — ticket id is now a `crypto.randomUUID()` string (Cosmos DB requires string ids)
- **Update** (`PATCH /:id`): Point read + [`container.item(id, id).replace(updated)`]((learn.microsoft.com/redacted)

### Required environment variables

Set these in your deployment environment (never commit them):

```
COSMOS_ENDPOINT=https://<your-account>.documents.azure.com:443/
COSMOS_KEY=<your-primary-key>
COSMOS_DATABASE_ID=SupportTicketsDB   # optional, this is the default
COSMOS_CONTAINER_ID=Tickets           # optional, this is the default
```

### Breaking change

Ticket `id` is now a UUID string instead of an auto-incrementing integer. Any existing API clients that pass integer ids to `GET /api/tickets/:id` or `PATCH /api/tickets/:id` will need to be updated to use the UUID returned from `POST`.

---

### Microsoft Learn references used

- Quickstart Node.js: (learn.microsoft.com/redacted)
- Get started (JS SDK): (learn.microsoft.com/redacted)
- Create item: (learn.microsoft.com/redacted)
- Read item: (learn.microsoft.com/redacted)
- Query items: (learn.microsoft.com/redacted)
- Replace item: (learn.microsoft.com/redacted)




> Generated by [Issue to Pull Request Agent](https://github.com/ChristinaPa/Issue-to-PR-automation-With-Custom-Agent/actions/runs/23733824720) for issue #6 · [◷](https://github.com/search?q=repo%3AChristinaPa%2FIssue-to-PR-automation-With-Custom-Agent+%22gh-aw-workflow-id%3A+issue-to-pr%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue to Pull Request Agent, engine: copilot, model: auto, id: 23733824720, workflow_id: issue-to-pr, run: https://github.com/ChristinaPa/Issue-to-PR-automation-With-Custom-Agent/actions/runs/23733824720 -->

<!-- gh-aw-workflow-id: issue-to-pr -->