### PR TITLE
Add DELETE endpoint to remove support tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The API starts on `http://localhost:3000`. Open `frontend/index.html` in a brows
 | `GET` | `/api/tickets/:id` | Get a single ticket |
 | `POST` | `/api/tickets` | Create and auto-route a ticket |
 | `PATCH` | `/api/tickets/:id` | Update ticket status |
+| `DELETE` | `/api/tickets/:id` | Delete a ticket |
 | `GET` | `/api/health` | Health check |
 
 ### Routing Logic

--- a/backend/routes/tickets.js
+++ b/backend/routes/tickets.js
@@ -90,4 +90,20 @@ router.patch("/:id", (req, res) => {
   res.json({ message: "Ticket updated", ticket });
 });
 
+// DELETE /api/tickets/:id — delete a ticket
+router.delete("/:id", (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  if (isNaN(id)) {
+    return res.status(400).json({ error: "Invalid ticket ID" });
+  }
+
+  const index = tickets.findIndex(t => t.id === id);
+  if (index === -1) {
+    return res.status(404).json({ error: "Ticket not found" });
+  }
+
+  tickets.splice(index, 1);
+  res.status(204).send();
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary

Adds a `DELETE /api/tickets/:id` endpoint so that resolved or spam tickets can be removed from the system.

## Changes

- **`backend/routes/tickets.js`** — New `DELETE /:id` route that:
  - Validates the `:id` parameter (returns `400` for non-numeric IDs)
  - Returns `404` if the ticket doesn't exist
  - Removes the ticket and returns `204 No Content` on success
- **`README.md`** — Updated the API endpoints table to document the new route

## Testing

Verified manually:
- `POST` a ticket → `201`
- `DELETE /api/tickets/1` → `204`
- `DELETE /api/tickets/999` (missing) → `404`
- `DELETE /api/tickets/abc` (invalid) → `400`
- `GET /api/tickets` after delete → count is 0

Closes #16